### PR TITLE
feat(dpuagent): write done marker file after all operations complete

### DIFF
--- a/internal/provisioning/dpuagent/dpuagent.go
+++ b/internal/provisioning/dpuagent/dpuagent.go
@@ -76,6 +76,8 @@ type DPUAgent struct {
 	rebootMethodDiscoveryFunc func(context.Context) bool
 	// writeDoneMarkerFunc, if non-nil, replaces the default marker writer (tests only).
 	writeDoneMarkerFunc func(dir string) error
+	// removeDoneMarkerFunc, if non-nil, replaces the default marker remover (tests only).
+	removeDoneMarkerFunc func(dir string) error
 }
 
 func NewDPUAgent(optCtx *operations.Context) *DPUAgent {
@@ -126,6 +128,13 @@ func (d *DPUAgent) Run(ctx context.Context) error {
 	}
 	if err := d.initCurrentBootID(); err != nil {
 		return err
+	}
+	removeMarker := removeDoneMarker
+	if d.removeDoneMarkerFunc != nil {
+		removeMarker = d.removeDoneMarkerFunc
+	}
+	if err := removeMarker(d.runDir); err != nil {
+		return fmt.Errorf("failed to remove stale done marker: %w", err)
 	}
 	for _, op := range d.operations {
 		if op.ShouldSkip(d.optCtx) {
@@ -237,6 +246,14 @@ func (d *DPUAgent) initCurrentBootID() error {
 		return fmt.Errorf("initialize current boot ID: %w", err)
 	}
 	d.optCtx.CurrentBootID = strings.TrimSpace(string(currentBootID))
+	return nil
+}
+
+func removeDoneMarker(dir string) error {
+	markerPath := filepath.Join(dir, doneMarkerFileName)
+	if err := os.Remove(markerPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale done marker %s: %w", markerPath, err)
+	}
 	return nil
 }
 

--- a/internal/provisioning/dpuagent/dpuagent.go
+++ b/internal/provisioning/dpuagent/dpuagent.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -60,13 +61,21 @@ const defaultRetryInterval = 30 * time.Second
 
 const bootIDFile = "/proc/sys/kernel/random/boot_id"
 
+const (
+	defaultRunDir      = "/run/dpu-agent"
+	doneMarkerFileName = "configuration-complete"
+)
+
 type DPUAgent struct {
 	optCtx        *operations.Context
 	operations    []operations.Operation
 	retryInterval time.Duration
+	runDir        string
 
 	// rebootMethodDiscoveryFunc, if non-nil, replaces MFT tool probing (tests only).
 	rebootMethodDiscoveryFunc func(context.Context) bool
+	// writeDoneMarkerFunc, if non-nil, replaces the default marker writer (tests only).
+	writeDoneMarkerFunc func(dir string) error
 }
 
 func NewDPUAgent(optCtx *operations.Context) *DPUAgent {
@@ -101,6 +110,7 @@ func NewDPUAgent(optCtx *operations.Context) *DPUAgent {
 	return &DPUAgent{
 		optCtx:     optCtx,
 		operations: operations,
+		runDir:     defaultRunDir,
 	}
 }
 
@@ -144,6 +154,13 @@ func (d *DPUAgent) Run(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("execution of operator %s aborted: %v", op.Name(), err)
 		}
+	}
+	writeMarker := writeDoneMarker
+	if d.writeDoneMarkerFunc != nil {
+		writeMarker = d.writeDoneMarkerFunc
+	}
+	if err := writeMarker(d.runDir); err != nil {
+		return fmt.Errorf("failed to write done marker: %w", err)
 	}
 	d.updateStatusUntilSuccess(ctx)
 	return nil
@@ -220,5 +237,17 @@ func (d *DPUAgent) initCurrentBootID() error {
 		return fmt.Errorf("initialize current boot ID: %w", err)
 	}
 	d.optCtx.CurrentBootID = strings.TrimSpace(string(currentBootID))
+	return nil
+}
+
+func writeDoneMarker(dir string) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create run directory %s: %w", dir, err)
+	}
+	markerPath := filepath.Join(dir, doneMarkerFileName)
+	if err := os.WriteFile(markerPath, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0644); err != nil {
+		return fmt.Errorf("write done marker file: %w", err)
+	}
+	klog.Infof("Configuration complete, marker written to %s", markerPath)
 	return nil
 }

--- a/internal/provisioning/dpuagent/dpuagent_test.go
+++ b/internal/provisioning/dpuagent/dpuagent_test.go
@@ -83,7 +83,67 @@ func newTestOptCtx(fakeClient client.Client) *operations.Context {
 }
 
 var _ = Describe("DPUAgent", func() {
+	Describe("Done marker", func() {
+		It("should write the done marker file after all operations complete successfully", func() {
+			dpu := newTestDPU()
+			fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(dpu).WithStatusSubresource(dpu).Build()
+			markerCalled := false
+
+			agent := &DPUAgent{
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: func(_ string) error { markerCalled = true; return nil },
+				optCtx:              newTestOptCtx(fakeClient),
+				operations: []operations.Operation{
+					&mockOperation{name: "op1", conditionType: "Op1Condition", executeFunc: func(_ context.Context, _ *operations.Context) error { return nil }},
+				},
+			}
+			Expect(agent.Run(ctx)).To(Succeed())
+			Expect(markerCalled).To(BeTrue())
+		})
+
+		It("should not write the done marker when the run is aborted", func() {
+			dpu := newTestDPU()
+			fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(dpu).WithStatusSubresource(dpu).Build()
+			cancelCtx, cancelFunc := context.WithCancel(ctx)
+			markerCalled := false
+
+			agent := &DPUAgent{
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: func(_ string) error { markerCalled = true; return nil },
+				optCtx:              newTestOptCtx(fakeClient),
+				operations: []operations.Operation{
+					&mockOperation{name: "cancel-op", conditionType: "CancelOpCondition", executeFunc: func(_ context.Context, _ *operations.Context) error {
+						cancelFunc()
+						return fmt.Errorf("error that triggers context check")
+					}},
+				},
+			}
+			err := agent.Run(cancelCtx)
+			Expect(err).To(HaveOccurred())
+			Expect(markerCalled).To(BeFalse())
+		})
+
+		It("should return error when writing the done marker fails", func() {
+			dpu := newTestDPU()
+			fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(dpu).WithStatusSubresource(dpu).Build()
+
+			agent := &DPUAgent{
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: func(_ string) error { return fmt.Errorf("disk full") },
+				optCtx:              newTestOptCtx(fakeClient),
+				operations: []operations.Operation{
+					&mockOperation{name: "op1", conditionType: "Op1Condition", executeFunc: func(_ context.Context, _ *operations.Context) error { return nil }},
+				},
+			}
+			err := agent.Run(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("done marker"))
+		})
+	})
+
 	Describe("Run", func() {
+		noopMarker := func(_ string) error { return nil }
+
 		It("should include package installation after static file verification", func() {
 			agent := NewDPUAgent(&operations.Context{})
 			names := make([]string, 0, len(agent.operations))
@@ -118,7 +178,7 @@ var _ = Describe("DPUAgent", func() {
 				}},
 			}
 
-			agent := &DPUAgent{retryInterval: testRetryInterval, optCtx: newTestOptCtx(fakeClient), operations: mockOps}
+			agent := &DPUAgent{retryInterval: testRetryInterval, writeDoneMarkerFunc: noopMarker, optCtx: newTestOptCtx(fakeClient), operations: mockOps}
 			Expect(agent.Run(ctx)).To(Succeed())
 			Expect(executionOrder).To(Equal([]string{"op1", "op2", "op3"}))
 		})
@@ -129,8 +189,9 @@ var _ = Describe("DPUAgent", func() {
 
 			var captured *provisioningv1.RebootMethodType
 			agent := &DPUAgent{
-				retryInterval: testRetryInterval,
-				optCtx:        newTestOptCtx(fakeClient),
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: noopMarker,
+				optCtx:              newTestOptCtx(fakeClient),
 				operations: []operations.Operation{
 					&mockOperation{name: "op1", conditionType: "Op1Condition", executeFunc: func(_ context.Context, optCtx *operations.Context) error {
 						captured = optCtx.Status.RebootMethod
@@ -149,8 +210,9 @@ var _ = Describe("DPUAgent", func() {
 
 			var discovery bool
 			agent := &DPUAgent{
-				retryInterval: testRetryInterval,
-				optCtx:        newTestOptCtx(fakeClient),
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: noopMarker,
+				optCtx:              newTestOptCtx(fakeClient),
 				operations: []operations.Operation{
 					&mockOperation{name: "op1", conditionType: "Op1Condition", executeFunc: func(_ context.Context, optCtx *operations.Context) error {
 						discovery = optCtx.RebootMethodDiscovery
@@ -169,6 +231,7 @@ var _ = Describe("DPUAgent", func() {
 			var discovery bool
 			agent := &DPUAgent{
 				retryInterval:             testRetryInterval,
+				writeDoneMarkerFunc:       noopMarker,
 				rebootMethodDiscoveryFunc: func(context.Context) bool { return true },
 				optCtx:                    newTestOptCtx(fakeClient),
 				operations: []operations.Operation{
@@ -191,6 +254,7 @@ var _ = Describe("DPUAgent", func() {
 			optCtx.Options.SkipRebootMethodDiscovery = true
 			agent := &DPUAgent{
 				retryInterval:             testRetryInterval,
+				writeDoneMarkerFunc:       noopMarker,
 				rebootMethodDiscoveryFunc: func(context.Context) bool { return true },
 				optCtx:                    optCtx,
 				operations: []operations.Operation{
@@ -210,8 +274,9 @@ var _ = Describe("DPUAgent", func() {
 
 			executionOrder := []string{}
 			agent := &DPUAgent{
-				retryInterval: testRetryInterval,
-				optCtx:        newTestOptCtx(fakeClient),
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: noopMarker,
+				optCtx:              newTestOptCtx(fakeClient),
 				operations: []operations.Operation{
 					&mockOperation{name: "op1", conditionType: "Op1Condition", executeFunc: func(_ context.Context, _ *operations.Context) error {
 						executionOrder = append(executionOrder, "op1")
@@ -237,8 +302,9 @@ var _ = Describe("DPUAgent", func() {
 
 			attempts := 0
 			agent := &DPUAgent{
-				retryInterval: testRetryInterval,
-				optCtx:        newTestOptCtx(fakeClient),
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: noopMarker,
+				optCtx:              newTestOptCtx(fakeClient),
 				operations: []operations.Operation{
 					&mockOperation{name: "flaky-op", conditionType: "FlakyOpCondition", executeFunc: func(_ context.Context, _ *operations.Context) error {
 						attempts++
@@ -259,8 +325,9 @@ var _ = Describe("DPUAgent", func() {
 			const condType = "Op1Condition"
 
 			agent := &DPUAgent{
-				retryInterval: testRetryInterval,
-				optCtx:        newTestOptCtx(fakeClient),
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: noopMarker,
+				optCtx:              newTestOptCtx(fakeClient),
 				operations: []operations.Operation{
 					&mockOperation{name: "op1", conditionType: condType, executeFunc: func(_ context.Context, optCtx *operations.Context) error {
 						optCtx.CondMessage = "custom success message"
@@ -282,8 +349,9 @@ var _ = Describe("DPUAgent", func() {
 			seen := []string{}
 
 			agent := &DPUAgent{
-				retryInterval: testRetryInterval,
-				optCtx:        newTestOptCtx(fakeClient),
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: noopMarker,
+				optCtx:              newTestOptCtx(fakeClient),
 				operations: []operations.Operation{
 					&mockOperation{name: "retry-op", conditionType: condType, executeFunc: func(_ context.Context, optCtx *operations.Context) error {
 						seen = append(seen, optCtx.CondMessage)
@@ -312,8 +380,9 @@ var _ = Describe("DPUAgent", func() {
 			secondSeen := "unset"
 
 			agent := &DPUAgent{
-				retryInterval: testRetryInterval,
-				optCtx:        newTestOptCtx(fakeClient),
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: noopMarker,
+				optCtx:              newTestOptCtx(fakeClient),
 				operations: []operations.Operation{
 					&mockOperation{name: "op1", conditionType: firstCond, executeFunc: func(_ context.Context, optCtx *operations.Context) error {
 						optCtx.CondMessage = "first message"
@@ -338,8 +407,9 @@ var _ = Describe("DPUAgent", func() {
 			failingOpAttempts := 0
 
 			agent := &DPUAgent{
-				retryInterval: testRetryInterval,
-				optCtx:        newTestOptCtx(fakeClient),
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: noopMarker,
+				optCtx:              newTestOptCtx(fakeClient),
 				operations: []operations.Operation{
 					&mockOperation{name: "failing-op", conditionType: "FailingOpCondition", executeFunc: func(_ context.Context, _ *operations.Context) error {
 						defer func() { failingOpAttempts++ }()
@@ -367,8 +437,9 @@ var _ = Describe("DPUAgent", func() {
 			secondOpExecuted := false
 
 			agent := &DPUAgent{
-				retryInterval: testRetryInterval,
-				optCtx:        newTestOptCtx(fakeClient),
+				retryInterval:       testRetryInterval,
+				writeDoneMarkerFunc: noopMarker,
+				optCtx:              newTestOptCtx(fakeClient),
 				operations: []operations.Operation{
 					&mockOperation{name: "blocking-op", conditionType: "BlockingOpCondition", executeFunc: func(_ context.Context, _ *operations.Context) error {
 						attempts++

--- a/internal/provisioning/dpuagent/dpuagent_test.go
+++ b/internal/provisioning/dpuagent/dpuagent_test.go
@@ -123,6 +123,47 @@ var _ = Describe("DPUAgent", func() {
 			Expect(markerCalled).To(BeFalse())
 		})
 
+		It("should remove a stale done marker at startup before operations run", func() {
+			dpu := newTestDPU()
+			fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(dpu).WithStatusSubresource(dpu).Build()
+			removeCalled := false
+			opExecuted := false
+
+			agent := &DPUAgent{
+				retryInterval:        testRetryInterval,
+				removeDoneMarkerFunc: func(_ string) error { removeCalled = true; return nil },
+				writeDoneMarkerFunc:  func(_ string) error { return nil },
+				optCtx:               newTestOptCtx(fakeClient),
+				operations: []operations.Operation{
+					&mockOperation{name: "op1", conditionType: "Op1Condition", executeFunc: func(_ context.Context, _ *operations.Context) error {
+						Expect(removeCalled).To(BeTrue(), "stale marker should be removed before operations run")
+						opExecuted = true
+						return nil
+					}},
+				},
+			}
+			Expect(agent.Run(ctx)).To(Succeed())
+			Expect(opExecuted).To(BeTrue())
+		})
+
+		It("should return error when removing the stale done marker fails", func() {
+			dpu := newTestDPU()
+			fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(dpu).WithStatusSubresource(dpu).Build()
+
+			agent := &DPUAgent{
+				retryInterval:        testRetryInterval,
+				removeDoneMarkerFunc: func(_ string) error { return fmt.Errorf("permission denied") },
+				writeDoneMarkerFunc:  func(_ string) error { return nil },
+				optCtx:               newTestOptCtx(fakeClient),
+				operations: []operations.Operation{
+					&mockOperation{name: "op1", conditionType: "Op1Condition", executeFunc: func(_ context.Context, _ *operations.Context) error { return nil }},
+				},
+			}
+			err := agent.Run(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("stale done marker"))
+		})
+
 		It("should return error when writing the done marker fails", func() {
 			dpu := newTestDPU()
 			fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(dpu).WithStatusSubresource(dpu).Build()


### PR DESCRIPTION
## Summary
- The dpu-agent now writes a marker file at `/run/dpu-agent/configuration-complete` once all operations have completed successfully.
- In OCP, we need a systemd dependency between the dpu-agent and kubelet so that kubelet only starts after the dpu-agent finishes all its configuration. This marker file enables other systemd units to use `ConditionPathExists=` or `PathExists=` to cleanly gate their startup on dpu-agent completion.
- The marker is written to `/run` (tmpfs), so it is automatically cleared on reboot. It is written before the final status update to avoid blocking on a potentially long-running status push.

## Test plan
- [x] Unit test: marker file is written after all operations complete successfully
- [x] Unit test: marker file is not written when the run is aborted (context cancellation)