### PR TITLE
fix(hostagent): bind mlx5_core to DPU PFs before configuring VFs

### DIFF
--- a/internal/provisioning/hostagent/networkmanager/network_manager.go
+++ b/internal/provisioning/hostagent/networkmanager/network_manager.go
@@ -186,6 +186,28 @@ func (nm *NetworkManager) processNetworkRequest(nr NetworkRequest) error {
 	}
 	operations := []networkOperation{
 		{
+			name: "EnsureDriverBoundP0",
+			f: func(nr NetworkRequest) error {
+				return hostutil.NewPCIHelper(nr.PCIAddress).PF(0).BindDriver("mlx5_core")
+			},
+		},
+		{
+			name: "EnsureDriverBoundP1",
+			f: func(nr NetworkRequest) error {
+				pf := hostutil.NewPCIHelper(nr.PCIAddress).PF(1)
+				isDPU, err := pf.IsDPU()
+				if err != nil {
+					if os.IsNotExist(err) {
+						return nil
+					}
+					return fmt.Errorf("failed to check if device is DPU: %w", err)
+				} else if !isDPU {
+					return nil
+				}
+				return pf.BindDriver("mlx5_core")
+			},
+		},
+		{
 			name: "CreateP0VF",
 			f: func(nr NetworkRequest) error {
 				return hostutil.NewPCIHelper(nr.PCIAddress).PF(0).SetNumOfVFs(nr.NumOfVFs)

--- a/internal/provisioning/hostagent/util/pci.go
+++ b/internal/provisioning/hostagent/util/pci.go
@@ -144,6 +144,38 @@ func (h *PCIHelper) SetNumOfVFs(num int) error {
 	return os.WriteFile(numvfsPath, []byte(fmt.Sprintf("%d", num)), 0644)
 }
 
+// IsDriverBound returns true if a driver is currently bound to the device.
+func (h *PCIHelper) IsDriverBound() (bool, error) {
+	if _, err := os.Lstat(filepath.Join(h.Path(), "driver")); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to stat driver symlink: %w", err)
+	}
+	return true, nil
+}
+
+// BindDriver writes the device's BDF to /sys/bus/pci/drivers/<driverName>/bind,
+// causing the kernel to attempt to bind the named driver to the device.
+// No-op if a driver is already bound. May block while the kernel runs the
+// driver's probe routine; if the device's firmware is in pre-init, the bind
+// can return -ETIMEDOUT after the kernel's wait_fw_init timeout.
+func (h *PCIHelper) BindDriver(driverName string) error {
+	bound, err := h.IsDriverBound()
+	if err != nil {
+		return err
+	}
+	if bound {
+		return nil
+	}
+	bdf := filepath.Base(h.Path())
+	bindPath := filepath.Join(h.sysFSRoot, "bus/pci/drivers", driverName, "bind")
+	if err := os.WriteFile(bindPath, []byte(bdf), 0644); err != nil {
+		return fmt.Errorf("failed to bind %s to %s: %w", bdf, driverName, err)
+	}
+	return nil
+}
+
 // GetMTU returns the current MTU of the PF interface
 func (h *PCIHelper) GetMTU() (int, error) {
 	interfaceName, err := h.InterfaceName()

--- a/internal/provisioning/hostagent/util/pci.go
+++ b/internal/provisioning/hostagent/util/pci.go
@@ -144,31 +144,39 @@ func (h *PCIHelper) SetNumOfVFs(num int) error {
 	return os.WriteFile(numvfsPath, []byte(fmt.Sprintf("%d", num)), 0644)
 }
 
-// IsDriverBound returns true if a driver is currently bound to the device.
-func (h *PCIHelper) IsDriverBound() (bool, error) {
-	if _, err := os.Lstat(filepath.Join(h.Path(), "driver")); err != nil {
+// BoundDriver returns the name of the driver currently bound to the device,
+// or empty string if no driver is bound.
+func (h *PCIHelper) BoundDriver() (string, error) {
+	target, err := os.Readlink(filepath.Join(h.Path(), "driver"))
+	if err != nil {
 		if os.IsNotExist(err) {
-			return false, nil
+			return "", nil
 		}
-		return false, fmt.Errorf("failed to stat driver symlink: %w", err)
+		return "", fmt.Errorf("failed to read driver symlink: %w", err)
 	}
-	return true, nil
+	return filepath.Base(target), nil
 }
 
 // BindDriver writes the device's BDF to /sys/bus/pci/drivers/<driverName>/bind,
 // causing the kernel to attempt to bind the named driver to the device.
-// No-op if a driver is already bound. May block while the kernel runs the
-// driver's probe routine; if the device's firmware is in pre-init, the bind
-// can return -ETIMEDOUT after the kernel's wait_fw_init timeout.
+// No-op if the named driver is already bound. Returns an error if a *different*
+// driver is bound — silently overriding could disrupt setups that intentionally
+// bound the device to another driver (e.g. vfio-pci for passthrough).
+// May block while the kernel runs the driver's probe routine; if the device's
+// firmware is in pre-init, the bind can return -ETIMEDOUT after the kernel's
+// wait_fw_init timeout.
 func (h *PCIHelper) BindDriver(driverName string) error {
-	bound, err := h.IsDriverBound()
+	boundDriver, err := h.BoundDriver()
 	if err != nil {
 		return err
 	}
-	if bound {
+	if boundDriver == driverName {
 		return nil
 	}
 	bdf := filepath.Base(h.Path())
+	if boundDriver != "" {
+		return fmt.Errorf("device %s is bound to driver %q, expected %q", bdf, boundDriver, driverName)
+	}
 	bindPath := filepath.Join(h.sysFSRoot, "bus/pci/drivers", driverName, "bind")
 	if err := os.WriteFile(bindPath, []byte(bdf), 0644); err != nil {
 		return fmt.Errorf("failed to bind %s to %s: %w", bdf, driverName, err)

--- a/internal/provisioning/hostagent/util/pci_test.go
+++ b/internal/provisioning/hostagent/util/pci_test.go
@@ -522,18 +522,18 @@ var _ = Describe("PCI", func() {
 		})
 	})
 
-	Context("PCIHelper.IsDriverBound", Label("PCIHelper", "IsDriverBound"), func() {
-		It("should return false when device has no driver symlink", func() {
+	Context("PCIHelper.BoundDriver", Label("PCIHelper", "BoundDriver"), func() {
+		It("should return empty string when device has no driver symlink", func() {
 			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
 			defer mock.Cleanup()
 
 			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
-			bound, err := helper.IsDriverBound()
+			driver, err := helper.BoundDriver()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(bound).To(BeFalse())
+			Expect(driver).To(Equal(""))
 		})
 
-		It("should return true when driver symlink exists", func() {
+		It("should return the driver name when a driver is bound", func() {
 			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
 			defer mock.Cleanup()
 
@@ -544,9 +544,24 @@ var _ = Describe("PCI", func() {
 			Expect(os.Symlink(driverTarget, driverSymlink)).To(Succeed())
 
 			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
-			bound, err := helper.IsDriverBound()
+			driver, err := helper.BoundDriver()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(bound).To(BeTrue())
+			Expect(driver).To(Equal("mlx5_core"))
+		})
+
+		It("should return the correct name for a different driver (e.g. vfio-pci)", func() {
+			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
+			defer mock.Cleanup()
+
+			driverTarget := filepath.Join(mock.TempSysfsDir(), "bus/pci/drivers/vfio-pci")
+			Expect(os.MkdirAll(driverTarget, 0755)).To(Succeed())
+			driverSymlink := filepath.Join(mock.PCIDevicesDir(), "0000:b1:00.0", "driver")
+			Expect(os.Symlink(driverTarget, driverSymlink)).To(Succeed())
+
+			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
+			driver, err := helper.BoundDriver()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(driver).To(Equal("vfio-pci"))
 		})
 	})
 
@@ -569,7 +584,7 @@ var _ = Describe("PCI", func() {
 			Expect(string(content)).To(Equal("0000:b1:00.0"))
 		})
 
-		It("should be a no-op when a driver is already bound", func() {
+		It("should be a no-op when the named driver is already bound", func() {
 			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
 			defer mock.Cleanup()
 
@@ -587,6 +602,33 @@ var _ = Describe("PCI", func() {
 			Expect(helper.BindDriver("mlx5_core")).To(Succeed())
 
 			content, err := os.ReadFile(bindPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal("untouched"))
+		})
+
+		It("should return error when a different driver is already bound", func() {
+			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
+			defer mock.Cleanup()
+
+			// Bind the device to vfio-pci (not what we want)
+			otherDriverTarget := filepath.Join(mock.TempSysfsDir(), "bus/pci/drivers/vfio-pci")
+			Expect(os.MkdirAll(otherDriverTarget, 0755)).To(Succeed())
+			driverSymlink := filepath.Join(mock.PCIDevicesDir(), "0000:b1:00.0", "driver")
+			Expect(os.Symlink(otherDriverTarget, driverSymlink)).To(Succeed())
+
+			// Create mlx5_core bind file too, pre-populated to detect any unwanted writes
+			mlx5BindDir := filepath.Join(mock.TempSysfsDir(), "bus/pci/drivers/mlx5_core")
+			Expect(os.MkdirAll(mlx5BindDir, 0755)).To(Succeed())
+			mlx5BindPath := filepath.Join(mlx5BindDir, "bind")
+			Expect(os.WriteFile(mlx5BindPath, []byte("untouched"), 0644)).To(Succeed())
+
+			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
+			err := helper.BindDriver("mlx5_core")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`device 0000:b1:00.0 is bound to driver "vfio-pci", expected "mlx5_core"`))
+
+			// Confirm we did NOT write to the mlx5_core bind file
+			content, err := os.ReadFile(mlx5BindPath)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(Equal("untouched"))
 		})

--- a/internal/provisioning/hostagent/util/pci_test.go
+++ b/internal/provisioning/hostagent/util/pci_test.go
@@ -522,6 +522,86 @@ var _ = Describe("PCI", func() {
 		})
 	})
 
+	Context("PCIHelper.IsDriverBound", Label("PCIHelper", "IsDriverBound"), func() {
+		It("should return false when device has no driver symlink", func() {
+			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
+			defer mock.Cleanup()
+
+			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
+			bound, err := helper.IsDriverBound()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bound).To(BeFalse())
+		})
+
+		It("should return true when driver symlink exists", func() {
+			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
+			defer mock.Cleanup()
+
+			// Create a fake driver symlink to mimic the kernel binding the device
+			driverTarget := filepath.Join(mock.TempSysfsDir(), "bus/pci/drivers/mlx5_core")
+			Expect(os.MkdirAll(driverTarget, 0755)).To(Succeed())
+			driverSymlink := filepath.Join(mock.PCIDevicesDir(), "0000:b1:00.0", "driver")
+			Expect(os.Symlink(driverTarget, driverSymlink)).To(Succeed())
+
+			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
+			bound, err := helper.IsDriverBound()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bound).To(BeTrue())
+		})
+	})
+
+	Context("PCIHelper.BindDriver", Label("PCIHelper", "BindDriver"), func() {
+		It("should write the BDF to the driver's bind file when no driver is bound", func() {
+			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
+			defer mock.Cleanup()
+
+			// Create the driver's bind file (kernel-managed in real sysfs)
+			bindDir := filepath.Join(mock.TempSysfsDir(), "bus/pci/drivers/mlx5_core")
+			Expect(os.MkdirAll(bindDir, 0755)).To(Succeed())
+			bindPath := filepath.Join(bindDir, "bind")
+			Expect(os.WriteFile(bindPath, []byte{}, 0644)).To(Succeed())
+
+			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
+			Expect(helper.BindDriver("mlx5_core")).To(Succeed())
+
+			content, err := os.ReadFile(bindPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal("0000:b1:00.0"))
+		})
+
+		It("should be a no-op when a driver is already bound", func() {
+			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
+			defer mock.Cleanup()
+
+			// Pre-bind by creating the driver symlink
+			driverTarget := filepath.Join(mock.TempSysfsDir(), "bus/pci/drivers/mlx5_core")
+			Expect(os.MkdirAll(driverTarget, 0755)).To(Succeed())
+			driverSymlink := filepath.Join(mock.PCIDevicesDir(), "0000:b1:00.0", "driver")
+			Expect(os.Symlink(driverTarget, driverSymlink)).To(Succeed())
+
+			// Create the bind file too, but pre-populated to detect any unwanted writes
+			bindPath := filepath.Join(driverTarget, "bind")
+			Expect(os.WriteFile(bindPath, []byte("untouched"), 0644)).To(Succeed())
+
+			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
+			Expect(helper.BindDriver("mlx5_core")).To(Succeed())
+
+			content, err := os.ReadFile(bindPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal("untouched"))
+		})
+
+		It("should return error when bind file does not exist", func() {
+			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
+			defer mock.Cleanup()
+
+			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
+			err := helper.BindDriver("mlx5_core")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to bind 0000:b1:00.0 to mlx5_core"))
+		})
+	})
+
 	Context("DiscoverDPUs", Label("DiscoverDPUs"), func() {
 		It("should return error when PCI devices directory does not exist", func() {
 			// Create mock to get cleanup() for path restoration, then point to non-existent path


### PR DESCRIPTION
On first dpu boot (OCP flow) the host kernel can probe mlx5_core while the DPU FW is still in pre-init, triggering a 120s wait_fw_init timeout that leaves no driver bound to the PFs. After that, processNetworkRequest fails forever in SetNumOfVFs because writes to sriov_numvfs return an error when no driver is bound (kernel logs "no driver bound to device; cannot configure SR-IOV" every reconcile tick).

Add EnsureDriverBoundP0 / EnsureDriverBoundP1 ops at the head of the processNetworkRequest operations slice, plus IsDriverBound and BindDriver helpers on PCIHelper. The reconcile loop's existing 30s retry handles the case where FW is not yet ready when the bind is attempted.

The fix is in the shared reconcile path and covers both vanilla DPF (driven by the DPUHostNetworkConfiguration phase handler) and OCP/HCP-provisioner (driven by DPU-side HTTP POST /configure-host-vfs). No protocol change.