### PR TITLE
feat: mount devinfo directory in sriov device plugin pod

### DIFF
--- a/internal/nodesriovdeviceplugin/controllers/pod.go
+++ b/internal/nodesriovdeviceplugin/controllers/pod.go
@@ -42,6 +42,8 @@ const (
 	devicePluginSocketVolumeName = "device-plugin-socket"
 	// sysVolumeName is the volume name for sysfs.
 	sysVolumeName = "sys"
+	// devInfoVolumeName is the volume name for the device info directory.
+	devInfoVolumeName = "devinfo"
 
 	// configMountPath is the path where the device plugin config is mounted.
 	configMountPath = "/etc/pcidp"
@@ -51,6 +53,8 @@ const (
 	devicePluginSocketMountPath = "/var/lib/kubelet/device-plugins"
 	// sysMountPath is the path for sysfs.
 	sysMountPath = "/sys"
+	// devInfoMountPath is the path for the device info directory used by the device plugin.
+	devInfoMountPath = "/var/run/k8s.cni.cncf.io/devinfo/dp"
 
 	// inputFileName is the name of the input file in the downward API volume.
 	inputFileName = "input.json"
@@ -71,6 +75,7 @@ func buildDesiredPod(
 
 	podName := generatePodName(nodeName)
 	hostPathDirectory := corev1.HostPathDirectory
+	hostPathDirectoryOrCreate := corev1.HostPathDirectoryOrCreate
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -141,6 +146,10 @@ func buildDesiredPod(
 							Name:      sysVolumeName,
 							MountPath: sysMountPath,
 						},
+						{
+							Name:      devInfoVolumeName,
+							MountPath: devInfoMountPath,
+						},
 					},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: ptr.To(true),
@@ -187,6 +196,15 @@ func buildDesiredPod(
 						HostPath: &corev1.HostPathVolumeSource{
 							Path: "/sys",
 							Type: &hostPathDirectory,
+						},
+					},
+				},
+				{
+					Name: devInfoVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: devInfoMountPath,
+							Type: &hostPathDirectoryOrCreate,
 						},
 					},
 				},


### PR DESCRIPTION
## Summary
- Mount `/var/run/k8s.cni.cncf.io/devinfo/dp` as a HostPath volume (DirectoryOrCreate) in the sriov device plugin container
- This path is required by the device plugin to write device information files per the [device-info-spec](https://github.com/k8snetworkplumbingwg/device-info-spec), enabling CNI plugins to discover extended device properties (PCI address, PF mapping, etc.)
- Matches the upstream [sriov-network-device-plugin DaemonSet](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin/blob/master/deployments/sriovdp-daemonset.yaml) volume configuration

## Test plan
- [x] Built dpf-system image and deployed to dev cluster
- [x] Verified controller detects outdated pod and recreates it with the new volume mount
- [x] Confirmed the volume mount is present at the expected path in the running device plugin pod