### PR TITLE
fix(hostagent): skip redundant network request file write on reconcile

### DIFF
--- a/internal/provisioning/hostagent/networkmanager/network_manager.go
+++ b/internal/provisioning/hostagent/networkmanager/network_manager.go
@@ -269,9 +269,11 @@ func (nm *NetworkManager) processNetworkRequest(nr NetworkRequest) error {
 				if err != nil {
 					return fmt.Errorf("failed to get VF name: %w", err)
 				}
-				nr.VFName = vfName
-				if err := writeNetworkRequestFile(&nr); err != nil {
-					return fmt.Errorf("failed to update vf name in network request file: %w", err)
+				if nr.VFName != vfName {
+					nr.VFName = vfName
+					if err := writeNetworkRequestFile(&nr); err != nil {
+						return fmt.Errorf("failed to update vf name in network request file: %w", err)
+					}
 				}
 				return hostutil.AddVFToBridge(nr.VFName, hostutil.OOBBridge.GetBridgeName())
 			},


### PR DESCRIPTION
## Summary

- The `AddVFToBridge` operation in the hostagent network manager unconditionally rewrote the network request file every 30-second reconcile tick, even when the VF name had not changed.
- Guard the write behind a comparison so the file is only updated when the VF interface name actually differs, eliminating noisy `wrote network request file` log lines.

## Test plan

- Deploy hostagent with this change and verify `wrote network request file` log only appears on first reconcile (or when VF name changes), not every 30 seconds.