### PR TITLE
fix(hostagent): avoid EBUSY when setting sriov_numvfs

### DIFF
--- a/internal/provisioning/hostagent/util/pci.go
+++ b/internal/provisioning/hostagent/util/pci.go
@@ -196,6 +196,21 @@ func (h *PCIHelper) SetNumOfVFs(num int) error {
 		}
 		return fmt.Errorf("failed to stat sriov_numvfs path: %w", err)
 	}
+	current, err := os.ReadFile(numvfsPath)
+	if err == nil {
+		val, parseErr := strconv.Atoi(strings.TrimSpace(string(current)))
+		if parseErr == nil {
+			if val == num {
+				return nil
+			}
+			// Kernel requires writing 0 before changing to a different non-zero value.
+			if val != 0 && num != 0 {
+				if err := os.WriteFile(numvfsPath, []byte("0"), 0644); err != nil {
+					return fmt.Errorf("failed to reset sriov_numvfs to 0: %w", err)
+				}
+			}
+		}
+	}
 	if err := os.WriteFile(numvfsPath, []byte(fmt.Sprintf("%d", num)), 0644); err != nil {
 		return h.errWriteSriovNumVFs(err)
 	}

--- a/internal/provisioning/hostagent/util/pci_test.go
+++ b/internal/provisioning/hostagent/util/pci_test.go
@@ -535,6 +535,39 @@ var _ = Describe("PCI", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(content)).To(Equal("0"))
 		})
+
+		It("should skip write when already at desired VF count", func() {
+			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
+			defer mock.Cleanup()
+
+			numvfsPath := filepath.Join(mock.PCIDevicesDir(), "0000:b1:00.0", "sriov_numvfs")
+			err := os.WriteFile(numvfsPath, []byte("4"), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Make the file read-only to prove no write happens
+			Expect(os.Chmod(numvfsPath, 0444)).To(Succeed())
+
+			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
+			err = helper.SetNumOfVFs(4)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reset to 0 before changing to a different non-zero VF count", func() {
+			mock := createMockSysfs("0000:b1:00.0", "0xa2dc\n", "", nil, "")
+			defer mock.Cleanup()
+
+			numvfsPath := filepath.Join(mock.PCIDevicesDir(), "0000:b1:00.0", "sriov_numvfs")
+			err := os.WriteFile(numvfsPath, []byte("2"), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			helper := NewPCIHelper("0000:b1:00.0").SetSysFS(mock.TempSysfsDir())
+			err = helper.SetNumOfVFs(4)
+			Expect(err).NotTo(HaveOccurred())
+
+			content, err := os.ReadFile(numvfsPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(content)).To(Equal("4"))
+		})
 	})
 
 	Context("PCIHelper.BoundDriver", Label("PCIHelper", "BoundDriver"), func() {


### PR DESCRIPTION
The kernel returns EBUSY when writing to sriov_numvfs if VFs already exist. This happens in two scenarios during reconciliation:

1. The desired VF count is already configured (redundant write).
2. A different non-zero VF count is requested without first resetting to 0.

Read the current sriov_numvfs value before writing:
- If it already matches, skip the write entirely.
- If changing from one non-zero value to another, write 0 first to tear down existing VFs before setting the new count.

Example error seen in production:
  failed to execute operation CreateP0VF: write /sys/bus/pci/devices/0000:b5:00.0/sriov_numvfs: device or resource busy