### PR TITLE
fix(helm): replace per-SA SCC bindings with namespace-wide Group binding

### DIFF
--- a/deploy/charts/dpf-operator/templates/openshift/privileged-scc-cluster-role-binding.yaml
+++ b/deploy/charts/dpf-operator/templates/openshift/privileged-scc-cluster-role-binding.yaml
@@ -6,66 +6,13 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: dpf-operator
     app.kubernetes.io/part-of: dpf-operator
-    dpu.nvidia.com/component: dpf-operator-controller-manager
-  name: dpf-provisioning-manager-scc-rolebinding
+  name: dpf-system-scc-privileged
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: system:openshift:scc:privileged
 subjects:
-  - kind: ServiceAccount
-    name: dpf-provisioning-controller-manager
-    namespace: {{  .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: dpf-operator
-    app.kubernetes.io/part-of: dpf-operator
-    dpu.nvidia.com/component: dpf-operator-controller-manager
-  name: dpf-operator-scc-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:openshift:scc:privileged
-subjects:
-  - kind: ServiceAccount
-    name: dpf-operator-controller-manager
-    namespace: {{  .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/part-of: dpf-operator
-    dpu.nvidia.com/component: dpu-detector
-  name: dpu-detector-scc-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:openshift:scc:privileged
-subjects:
-  - kind: ServiceAccount
-    name: dpu-detector
-    namespace: {{  .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/part-of: dpf-operator
-  name: dpf-provisioning-dms-scc-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:openshift:scc:privileged
-subjects:
-  - kind: ServiceAccount
-    name: dpf-provisioning-dms-service-account
-    namespace: {{  .Release.Namespace }}
----
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:serviceaccounts:{{  .Release.Namespace }}
 {{ end }}


### PR DESCRIPTION
## Summary
- Replace 4 individual ServiceAccount SCC ClusterRoleBindings with a single namespace-wide Group binding (`system:serviceaccounts:<namespace>`)
- Grants privileged SCC to all service accounts in the release namespace, covering existing SAs (like `static-cm-controller-manager` and `dpuservice-controller-manager`) and any future ones automatically
- Only rendered when `isOpenshift: true`

## Cleanup
After upgrading the chart, remove the old per-SA bindings from the cluster:
```bash
oc delete clusterrolebinding \
  dpf-provisioning-manager-scc-rolebinding \
  dpf-operator-scc-rolebinding \
  dpu-detector-scc-rolebinding \
  dpf-provisioning-dms-scc-rolebinding \
  --ignore-not-found
```

## Test plan
- [ ] Deploy chart with `--set isOpenshift=true` and verify `dpf-system-scc-privileged` ClusterRoleBinding is created
- [ ] Verify all SAs in the namespace can run privileged pods
- [ ] Deploy chart with `isOpenshift=false` (default) and verify no SCC binding is created


Made with [Cursor](https://cursor.com)