### PR TITLE
Fix missing SCC bindings for controller managers

### DIFF
--- a/deploy/charts/dpf-operator/templates/openshift/privileged-scc-cluster-role-binding.yaml
+++ b/deploy/charts/dpf-operator/templates/openshift/privileged-scc-cluster-role-binding.yaml
@@ -68,4 +68,40 @@ subjects:
     name: dpf-provisioning-dms-service-account
     namespace: {{  .Release.Namespace }}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dpf-operator
+    app.kubernetes.io/part-of: dpf-operator
+    dpu.nvidia.com/component: dpuservice-controller-manager
+  name: dpuservice-scc-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: dpuservice-controller-manager
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dpf-operator
+    app.kubernetes.io/part-of: dpf-operator
+    dpu.nvidia.com/component: static-cm-controller-manager
+  name: static-cm-scc-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+subjects:
+  - kind: ServiceAccount
+    name: static-cm-controller-manager
+    namespace: {{ .Release.Namespace }}
+---
 {{ end }}


### PR DESCRIPTION
Fixes dpuservice-controller-manager and static-cm-controller-manager deployment failures on OpenShift.

Controllers run as user 65532 but lack privileged SCC permissions, causing SCC violations.

Tested on OpenShift 4.22 - controllers now start successfully.