### PR TITLE
fix(hostagent): check PF interface before writing sriov_numvfs

### DIFF
--- a/internal/provisioning/hostagent/networkmanager/network_manager.go
+++ b/internal/provisioning/hostagent/networkmanager/network_manager.go
@@ -248,13 +248,18 @@ func (nm *NetworkManager) processNetworkRequest(nr NetworkRequest) error {
 		{
 			name: "CreateP0VF",
 			f: func(nr NetworkRequest) error {
-				return hostutil.NewPCIHelper(nr.PCIAddress).PF(0).SetNumOfVFs(nr.NumOfVFs)
+				pf := hostutil.NewPCIHelper(nr.PCIAddress).PF(0)
+				if _, err := pf.InterfaceName(); err != nil {
+					return fmt.Errorf("PF0 net interface not available, DPU firmware may still be initializing: %w", err)
+				}
+				return pf.SetNumOfVFs(nr.NumOfVFs)
 			},
 		},
 		{
 			name: "CreateP1VF",
 			f: func(nr NetworkRequest) error {
-				isDPU, err := hostutil.NewPCIHelper(nr.PCIAddress).PF(1).IsDPU()
+				pf := hostutil.NewPCIHelper(nr.PCIAddress).PF(1)
+				isDPU, err := pf.IsDPU()
 				if err != nil {
 					if os.IsNotExist(err) {
 						return nil
@@ -263,7 +268,10 @@ func (nm *NetworkManager) processNetworkRequest(nr NetworkRequest) error {
 				} else if !isDPU {
 					return nil
 				}
-				return hostutil.NewPCIHelper(nr.PCIAddress).PF(1).SetNumOfVFs(nr.NumOfVFs)
+				if _, err := pf.InterfaceName(); err != nil {
+					return fmt.Errorf("PF1 net interface not available, DPU firmware may still be initializing: %w", err)
+				}
+				return pf.SetNumOfVFs(nr.NumOfVFs)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Guard `SetNumOfVFs` with a PF interface check before writing `sriov_numvfs`
- Prevents a catastrophic VF probe cascade (~46 VFs × 120s timeout each) when `mlx5_core` is in error state after firmware fatal error
- The 30s reconcile loop naturally retries once the DPU firmware recovers

## Problem
When the DPU firmware hits a fatal error during provisioning, `mlx5_core` on the host enters error state and tears down the netdev — but remains bound to the PCI device. The network manager's `CreateP0VF` step writes `sriov_numvfs` regardless, triggering the kernel to enumerate dozens of VFs that each block 120s in `wait_fw_init`, resulting in 90+ minutes of stuck kernel threads and failed provisioning.

## Fix
Check that the PF has a net interface (proving the driver is healthy and firmware is responsive) before calling `SetNumOfVFs`. If the interface is missing, return an error early — the network manager retries every 30s and will succeed once the DPU finishes booting.

## Test plan
- [ ] Verify unit tests pass (`go test ./internal/provisioning/hostagent/util/`)
- [ ] Deploy on a cluster and provision a DPU — confirm VFs are created normally when PF is healthy
- [ ] Simulate firmware error scenario (or trigger BFB install) — confirm no VF cascade, provisioning recovers after DPU boot


Made with [Cursor](https://cursor.com)