### PR TITLE
feat(provisioning): add /set-error HTTP endpoint to hostagent

### DIFF
--- a/internal/provisioning/hostagent/service/installation_service.go
+++ b/internal/provisioning/hostagent/service/installation_service.go
@@ -135,6 +135,11 @@ func NewInstallationService(client client.Client, nm NetworkConfigurator, rh Reb
 			Consumes(restful.MIME_JSON).
 			Produces(restful.MIME_JSON).
 			To(s.RebindHostDriver))
+	ws.Route(
+		ws.POST("/set-error").
+			Consumes(restful.MIME_JSON).
+			Produces(restful.MIME_JSON).
+			To(s.SetError))
 	ws.Route(ws.GET("/healthz").To(s.HealthCheck))
 	// Package repositories: serve .deb and .rpm packages for DPU provisioning.
 	ws.Route(ws.GET("/deb/{subpath:*}").To(serveRepoFile(debRepoDir)))
@@ -493,6 +498,53 @@ func (s *InstallationService) TriggerReboot(req *restful.Request, resp *restful.
 	}
 
 	klog.Infof("Successfully triggered reboot (%s) for DPU %s/%s", request.RebootMethod, request.DPUNamespace, request.DPUName)
+	resp.WriteHeader(http.StatusOK)
+}
+
+func (s *InstallationService) SetError(req *restful.Request, resp *restful.Response) {
+	var request types.SetErrorRequest
+	if err := req.ReadEntity(&request); err != nil {
+		klog.Errorf("failed to read set error request: %v", err)
+		_ = resp.WriteError(http.StatusBadRequest, err)
+		return
+	}
+	klog.Infof("Received set error request for DPU %s/%s: reason=%s, message=%s",
+		request.DPUNamespace, request.DPUName, request.Reason, request.Message)
+
+	dpu := &provisioningv1.DPU{}
+	if err := s.Get(req.Request.Context(), client.ObjectKey{Namespace: request.DPUNamespace, Name: request.DPUName}, dpu); err != nil {
+		klog.Errorf("failed to get DPU %s/%s: %v", request.DPUNamespace, request.DPUName, err)
+		if apierrors.IsNotFound(err) {
+			_ = resp.WriteError(http.StatusNotFound, err)
+		} else {
+			_ = resp.WriteError(http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	if string(dpu.UID) != request.DPUUID {
+		klog.Warningf("Rejecting set error request for DPU %s/%s: request UID %q does not match current DPU UID %q",
+			request.DPUNamespace, request.DPUName, request.DPUUID, dpu.UID)
+		_ = resp.WriteError(http.StatusConflict, fmt.Errorf("stale DPU object: expected UID %q but got %q", request.DPUUID, dpu.UID))
+		return
+	}
+
+	patch := client.MergeFrom(dpu.DeepCopy())
+	dpu.Status.Phase = provisioningv1.DPUError
+	meta.SetStatusCondition(&dpu.Status.Conditions, metav1.Condition{
+		Type:               string(provisioningv1.DPUCondError),
+		Status:             metav1.ConditionTrue,
+		Reason:             request.Reason,
+		Message:            request.Message,
+		LastTransitionTime: metav1.Now(),
+	})
+
+	if err := s.Status().Patch(req.Request.Context(), dpu, patch); err != nil {
+		klog.Errorf("failed to patch DPU %s/%s error status: %v", request.DPUNamespace, request.DPUName, err)
+		_ = resp.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+	klog.Infof("Successfully set error on DPU %s/%s", request.DPUNamespace, request.DPUName)
 	resp.WriteHeader(http.StatusOK)
 }
 

--- a/internal/provisioning/hostagent/service/installation_service_test.go
+++ b/internal/provisioning/hostagent/service/installation_service_test.go
@@ -773,4 +773,85 @@ var _ = Describe("InstallationService", func() {
 		})
 	})
 
+	Context("set error", func() {
+		It("should set DPU phase to Error and add DPUCondError condition", func() {
+			dpu := createDPU("test-dpu", testNS.Name)
+
+			request := types.SetErrorRequest{
+				DPUName:      dpu.Name,
+				DPUNamespace: dpu.Namespace,
+				DPUUID:       string(dpu.UID),
+				Reason:       "FatalFailure",
+				Message:      "something went wrong on the DPU",
+			}
+			req, err := json.Marshal(request)
+			Expect(err).To(Succeed())
+
+			resp, err := http.Post(fmt.Sprintf("http://%s/set-error", address), "application/json", bytes.NewBuffer(req))
+			Expect(err).To(Succeed())
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			updatedDPU := &provisioningv1.DPU{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: dpu.Namespace, Name: dpu.Name}, updatedDPU)).To(Succeed())
+			Expect(updatedDPU.Status.Phase).To(Equal(provisioningv1.DPUError))
+
+			By("DPUCondError condition should be set")
+			var errorCond *metav1.Condition
+			for i := range updatedDPU.Status.Conditions {
+				if updatedDPU.Status.Conditions[i].Type == string(provisioningv1.DPUCondError) {
+					errorCond = &updatedDPU.Status.Conditions[i]
+					break
+				}
+			}
+			Expect(errorCond).NotTo(BeNil())
+			Expect(errorCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(errorCond.Reason).To(Equal("FatalFailure"))
+			Expect(errorCond.Message).To(Equal("something went wrong on the DPU"))
+		})
+
+		It("should reject set error with mismatched DPU UID", func() {
+			dpu := createDPU("test-dpu", testNS.Name)
+
+			request := types.SetErrorRequest{
+				DPUName:      dpu.Name,
+				DPUNamespace: dpu.Namespace,
+				DPUUID:       "stale-uid-from-old-agent",
+				Reason:       "FatalFailure",
+				Message:      "something went wrong on the DPU",
+			}
+			req, err := json.Marshal(request)
+			Expect(err).To(Succeed())
+
+			resp, err := http.Post(fmt.Sprintf("http://%s/set-error", address), "application/json", bytes.NewBuffer(req))
+			Expect(err).To(Succeed())
+			Expect(resp.StatusCode).To(Equal(http.StatusConflict))
+
+			updatedDPU := &provisioningv1.DPU{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: dpu.Namespace, Name: dpu.Name}, updatedDPU)).To(Succeed())
+			Expect(updatedDPU.Status.Phase).NotTo(Equal(provisioningv1.DPUError))
+		})
+
+		It("should return 404 when DPU is not found", func() {
+			request := types.SetErrorRequest{
+				DPUName:      "non-existent-dpu",
+				DPUNamespace: testNS.Name,
+				DPUUID:       "some-uid",
+				Reason:       "FatalFailure",
+				Message:      "something went wrong on the DPU",
+			}
+			req, err := json.Marshal(request)
+			Expect(err).To(Succeed())
+
+			resp, err := http.Post(fmt.Sprintf("http://%s/set-error", address), "application/json", bytes.NewBuffer(req))
+			Expect(err).To(Succeed())
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+
+		It("should return 400 when request body is malformed", func() {
+			resp, err := http.Post(fmt.Sprintf("http://%s/set-error", address), "application/json", bytes.NewBufferString("not-json"))
+			Expect(err).To(Succeed())
+			Expect(resp.StatusCode).To(Equal(http.StatusBadRequest))
+		})
+	})
+
 })

--- a/internal/provisioning/hostagent/service/types/types.go
+++ b/internal/provisioning/hostagent/service/types/types.go
@@ -50,3 +50,11 @@ type RebindHostDriverRequest struct {
 	DPUNamespace string `json:"dpuNamespace"`
 	DPUUID       string `json:"dpuUID"`
 }
+
+type SetErrorRequest struct {
+	DPUName      string `json:"dpuName"`
+	DPUNamespace string `json:"dpuNamespace"`
+	DPUUID       string `json:"dpuUID"`
+	Reason       string `json:"reason"`
+	Message      string `json:"message"`
+}


### PR DESCRIPTION
## Summary

- Add a new `POST /set-error` HTTP endpoint on the hostagent InstallationService that transitions a DPU into the Error phase with a `DPUCondError` condition.
- The endpoint validates DPU UID to prevent stale updates, following the same pattern as `/trigger-reboot`.
- Enables the DPU agent to signal unrecoverable failures through the hostagent service.

## Test plan

- [ ] Unit tests added (happy path, UID mismatch 409, not found 404, malformed 400)
- [ ] Manual test: curl `/set-error` from hostagent pod, verify DPU phase transitions to Error

Made with [Cursor](https://cursor.com)