### PR TITLE
feat(provisioning): raise NVConfig parameter limit to 64

### DIFF
--- a/api/provisioning/v1alpha1/dpuflavor_types.go
+++ b/api/provisioning/v1alpha1/dpuflavor_types.go
@@ -229,7 +229,7 @@ type NVConfig struct {
 	// DELAY_HOST_OS_INIT=ENABLE_USER (0x3) holds the host at UEFI and is rejected by the DPU agent
 	// outside zero-trust, where the agent needs the host to reach the kube-apiserver.
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=32
+	// +kubebuilder:validation:MaxItems=64
 	// +kubebuilder:validation:items:Pattern=`^[^=\s]+=[^\s]*$`
 	// +kubebuilder:validation:items:MaxLength=200
 	// +listType=atomic

--- a/config/provisioning/crd/bases/provisioning.dpu.nvidia.com_dpuflavors.yaml
+++ b/config/provisioning/crd/bases/provisioning.dpu.nvidia.com_dpuflavors.yaml
@@ -356,7 +356,7 @@ spec:
                             maxLength: 200
                             pattern: ^[^=\s]+=[^\s]*$
                             type: string
-                          maxItems: 32
+                          maxItems: 64
                           minItems: 1
                           type: array
                           x-kubernetes-list-type: atomic
@@ -436,7 +436,7 @@ spec:
                         maxLength: 200
                         pattern: ^[^=\s]+=[^\s]*$
                         type: string
-                      maxItems: 32
+                      maxItems: 64
                       minItems: 1
                       type: array
                       x-kubernetes-list-type: atomic

--- a/deploy/charts/dpf-operator/templates/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpuflavors.provisioning.dpu.nvidia.com.yaml
+++ b/deploy/charts/dpf-operator/templates/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpuflavors.provisioning.dpu.nvidia.com.yaml
@@ -358,7 +358,7 @@ spec:
                             maxLength: 200
                             pattern: ^[^=\s]+=[^\s]*$
                             type: string
-                          maxItems: 32
+                          maxItems: 64
                           minItems: 1
                           type: array
                           x-kubernetes-list-type: atomic
@@ -438,7 +438,7 @@ spec:
                         maxLength: 200
                         pattern: ^[^=\s]+=[^\s]*$
                         type: string
-                      maxItems: 32
+                      maxItems: 64
                       minItems: 1
                       type: array
                       x-kubernetes-list-type: atomic

--- a/docs/public/developer-guides/api/api.md
+++ b/docs/public/developer-guides/api/api.md
@@ -3611,7 +3611,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `device` _string_ | Device is the device to which the configuration applies. If not specified, the configuration applies to all.<br />Supported values: "*" (wildcard for all devices), "p0"/"P0" (port 0), "p1"/"P1" (port 1). Case-insensitive. |  | Enum: [* p0 p1 P0 P1] <br />Optional: \{\} <br /> |
-| `parameters` _string array_ | Parameters are the parameters to be set for the device.<br />DELAY_HOST_OS_INIT=ENABLE_USER (0x3) holds the host at UEFI and is rejected by the DPU agent<br />outside zero-trust, where the agent needs the host to reach the kube-apiserver. |  | MaxItems: 32 <br />MinItems: 1 <br />items:MaxLength: 200 <br />items:Pattern: `^[^=\s]+=[^\s]*$` <br />Optional: \{\} <br /> |
+| `parameters` _string array_ | Parameters are the parameters to be set for the device.<br />DELAY_HOST_OS_INIT=ENABLE_USER (0x3) holds the host at UEFI and is rejected by the DPU agent<br />outside zero-trust, where the agent needs the host to reach the kube-apiserver. |  | MaxItems: 64 <br />MinItems: 1 <br />items:MaxLength: 200 <br />items:Pattern: `^[^=\s]+=[^\s]*$` <br />Optional: \{\} <br /> |
 | `force` _boolean_ | force applies the parameters with `mlxconfig --force` and skips the `mlxconfig q` filter,<br />so parameters firmware does not yet expose are applied now instead of deferred to a later<br />reboot. Required when a parameter is gated behind another parameter in the same batch.<br />Requires DOCA 3.5.0 or later; on an older DOCA version the operation fails.<br />`--force` skips validation for the whole batch, so an invalid value is applied silently.<br />Ignored under `spec.hostNetworkInterfaceConfigs[].nvconfig`. |  | Optional: \{\} <br /> |
 
 

--- a/docs/public/developer-guides/api/dpuflavor.md
+++ b/docs/public/developer-guides/api/dpuflavor.md
@@ -94,14 +94,14 @@ A one-of selector: exactly one field must be set, and each is an empty object th
 | Field | Type | Description |
 |-------|------|--------------|
 | `device` | *string | Target device: `"*"` (all devices), `"p0"`/`"P0"` (port 0), or `"p1"`/`"P1"` (port 1). Case-insensitive. |
-| `parameters` | []string | Firmware parameters in `KEY=VALUE` format. 1-32 params, max 200 chars each. |
+| `parameters` | []string | Optional firmware parameters in `KEY=VALUE` format. When present, 1-64 entries, max 200 characters each; empty values such as `FLAG=` are allowed. |
 | `force` | *bool | Apply the parameters with `mlxconfig --force` and skip the `mlxconfig q` deferral filter. Defaults to `false`. |
 
 **Validation Constraints:**
 - Maximum of 3 nvconfig entries per DPUFlavor (one per device: `*`, `p0`/`P0`, `p1`/`P1`)
 - Wildcard device (`"*"`) must be the sole entry when specified (no mixing with port-specific entries)
 - Device identifiers must be unique with case-insensitive matching (e.g., `p0` and `P0` are duplicates)
-- Parameters: 1-32 entries per device, each formatted as `KEY=VALUE` with no spaces allowed
+- Parameters are optional. When present, provide 1-64 `KEY=VALUE` entries with no whitespace; values may be empty
 
 #### IB Mode to Ethernet Mode Configuration
 

--- a/test/apivalidation/provisioning_api_validation_test.go
+++ b/test/apivalidation/provisioning_api_validation_test.go
@@ -504,24 +504,34 @@ var _ = Describe("Provisioning API Validation", func() {
 				// Note: MaxItems=3 constraint matches the maximum possible unique enum values
 				// (*, p0, p1). With uniqueness validation, this is the theoretical maximum.
 
-				It("should reject too many parameters (MaxItems=32)", func() {
+			})
+
+			DescribeTable("validates the maximum number of parameters",
+				func(name string, parameterCount int, expectError bool) {
 					obj := getMinimalDPUFlavor(testNs.Name)
-					obj.Name = "cel-maxitems-params"
-					params := make([]string, 33)
-					for i := 0; i < 33; i++ {
+					obj.Name = name
+					params := make([]string, parameterCount)
+					for i := range params {
 						params[i] = fmt.Sprintf("PARAM%d=value", i)
 					}
 					obj.Spec.NVConfig = []provisioningv1.NVConfig{
 						{Device: ptr.To("p0"), Parameters: params},
 					}
+
 					err := testClient.Create(ctx, obj)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Or(
-						ContainSubstring("maxItems"),
-						ContainSubstring("Too many"), // Capital T!
-					))
-				})
-			})
+					if expectError {
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(Or(
+							ContainSubstring("maxItems"),
+							ContainSubstring("Too many"), // Capital T!
+						))
+						return
+					}
+					Expect(err).ToNot(HaveOccurred())
+				},
+				Entry("accepts exactly 64 parameters", "cel-maxitems-params-64", 64, false),
+				Entry("rejects exactly 65 parameters", "cel-maxitems-params-65", 65, true),
+			)
 		})
 
 		DescribeTable("Validates exactly one HostOSInit releaseAfter gate",


### PR DESCRIPTION
## Summary

Raise each `DPUFlavor` `NVConfig.parameters` limit from 32 to 64.

[NVIDIA's documented CPU as Root Complex recipe](https://docs.nvidia.com/networking/display/mftv4341lts/mlxconfig-%E2%80%93-changing-device-configuration-tool) adds 18 platform parameters to NICo's existing 16, producing 34 entries and exceeding the existing bound. A limit of 64 accommodates the complete profile while keeping API input bounded.

This change expands API capacity only. Device selection and parameter application remain unchanged. It also regenerates the provisioning and Helm CRDs and API reference, updates the DPUFlavor guide, and verifies that 64 parameters are accepted while 65 are rejected.

## Testing

Just ran through:
```
go test -timeout 0 ./test/apivalidation
make lint
make verify-generate
CRDIFY_ORIGIN=upstream CRDIFY_BASE_REF=public-main CRDIFY_COMPARE_REF=HEAD make verify-crdify
```

Closes NVIDIA/infra-controller#5438.
